### PR TITLE
Add Linguist override for .vb files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.vb    linguist-language=vba


### PR DESCRIPTION
I noticed that you use the `.vb` extension for some of your VBA code. However, this extension is marked by [Linguist](https://github.com/github/linguist) as a `Visual Basic .NET` extension. To fix that, I've added a `.gitattributes` file with an override to fix that.

This way, the repo can be properly recognized as a VBA repo on GitHub (mainly in the languages breakdown and in searches).